### PR TITLE
Add basic Node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Web game, based on The Resistance - social deduction",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -2,6 +2,7 @@
 import { db, auth } from "./firebase-init.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js";
 import { doc, onSnapshot, updateDoc, deleteField, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js";
+import { missionTeamSize } from "./utils.mjs";
 
 const roomId = new URLSearchParams(location.search).get("room");
 const roomRef = doc(db, "rooms", roomId);
@@ -314,17 +315,6 @@ function renderBoard() {
 /* --------------------------------------------------------------------------- */
 /*                                 misc helpers                                */
 /* --------------------------------------------------------------------------- */
-function missionTeamSize(playerCount, mission) {
-  const tbl = {
-    5 : [0, 2, 3, 2, 3, 3],
-    6 : [0, 2, 3, 4, 3, 4],
-    7 : [0, 2, 3, 3, 4, 4],
-    8 : [0, 3, 4, 4, 5, 5],
-    9 : [0, 3, 4, 4, 5, 5],
-    10: [0, 3, 4, 4, 5, 5],
-  };
-  return tbl[playerCount][mission];
-}
 
 async function castVote(approve) {
   await updateDoc(roomRef, { [`votes.${me}`]: approve, lastActivity: serverTimestamp() });

--- a/public/js/utils.mjs
+++ b/public/js/utils.mjs
@@ -1,0 +1,11 @@
+export function missionTeamSize(playerCount, mission) {
+  const tbl = {
+    5 : [0, 2, 3, 2, 3, 3],
+    6 : [0, 2, 3, 4, 3, 4],
+    7 : [0, 2, 3, 3, 4, 4],
+    8 : [0, 3, 4, 4, 5, 5],
+    9 : [0, 3, 4, 4, 5, 5],
+    10: [0, 3, 4, 4, 5, 5],
+  };
+  return tbl[playerCount][mission];
+}

--- a/test/missionTeamSize.test.mjs
+++ b/test/missionTeamSize.test.mjs
@@ -1,0 +1,17 @@
+import { missionTeamSize } from '../public/js/utils.mjs';
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+describe('missionTeamSize', () => {
+  it('returns correct team sizes for 5 players', () => {
+    assert.strictEqual(missionTeamSize(5, 1), 2);
+    assert.strictEqual(missionTeamSize(5, 2), 3);
+    assert.strictEqual(missionTeamSize(5, 3), 2);
+    assert.strictEqual(missionTeamSize(5, 4), 3);
+    assert.strictEqual(missionTeamSize(5, 5), 3);
+  });
+
+  it('returns correct team size for 10 players mission 2', () => {
+    assert.strictEqual(missionTeamSize(10, 2), 4);
+  });
+});


### PR DESCRIPTION
## Summary
- extract `missionTeamSize` helper into its own module
- add tests using Node's built‑in test runner
- hook `npm test` to `node --test`

## Testing
- `npm test`

