### PR TITLE
Improve lobby UX by using toast notifications

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -76,5 +76,7 @@
   </div>
   <!-- /#root -->
 
+  <div id="notification-container"></div>
+
 </body>
 </html>

--- a/public/join.html
+++ b/public/join.html
@@ -110,5 +110,6 @@
 
     </div>
   </div>
+  <div id="notification-container"></div>
 </body>
 </html>

--- a/public/js/join.js
+++ b/public/js/join.js
@@ -1,6 +1,7 @@
 /* /public/js/join.js  —  redesigned home‑screen logic */
 
 import { db, auth } from "./firebase-init.js";
+import { showToast } from "./toast.js";
 import { onAuthStateChanged }
   from "https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js";
 import {
@@ -181,7 +182,7 @@ createBtn.onclick = async () => {
     location.href = `/lobby.html?room=${ref.id}`;
   } catch (error) {
     console.error("Failed to create room:", error);
-    alert("Could not create the room. Please try again.");
+    showToast("Could not create the room. Please try again.", "fail");
     // --- RESTORE BUTTON ON FAILURE ---
     createBtn.disabled = false;
     createBtn.textContent = "Create Room";

--- a/public/js/toast.js
+++ b/public/js/toast.js
@@ -1,0 +1,19 @@
+export function showToast(message, type = '') {
+  const container = document.getElementById('notification-container');
+  if (!container) {
+    console.warn('Toast container not found');
+    return;
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  if (type) toast.classList.add(type);
+  toast.textContent = message;
+  container.appendChild(toast);
+  // Trigger animation
+  requestAnimationFrame(() => toast.classList.add('show'));
+  // Auto remove
+  setTimeout(() => {
+    toast.classList.remove('show');
+    toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+  }, 3000);
+}


### PR DESCRIPTION
## Summary
- create a simple `showToast` helper for on-page notifications
- show toast notifications for lobby events and creation errors
- prevent the browser leave-confirm when starting the game
- add notification container to Join and Game pages

## Testing
- `npm test` *(fails: Error: no test specified)*
