### PR TITLE
Fix invite joining flow

### DIFF
--- a/public/js/join.js
+++ b/public/js/join.js
@@ -28,6 +28,17 @@ if (savedNick) {
   nickname.value = savedNick;
   checkFields()
 }
+
+// If arriving via an invite link (?room=XYZ), auto-join that room.
+const invitedRoomId = new URLSearchParams(location.search).get("room");
+if (invitedRoomId) {
+  (async () => {
+    // Use saved nickname if available, otherwise prompt the player.
+    const nick = savedNick || prompt("Enter a nickname to join the game:");
+    if (!nick) return;
+    await joinRoom(invitedRoomId, nick.trim());
+  })();
+}
 function checkFields() {
   createBtn.disabled = !(roomName.value.trim() && nickname.value.trim());
 }

--- a/public/js/lobby.js
+++ b/public/js/lobby.js
@@ -60,20 +60,10 @@ onAuthStateChanged(auth, (user) => {
         }, 60000);
 
     } else {
-        // User is signed out.
-        me = null;
-        
-        // Clean up the listener if it exists.
-        if (unsubscribeFromRoom) {
-            unsubscribeFromRoom();
-            unsubscribeFromRoom = null;
-        }
-        window.removeEventListener("pagehide", leaveLobby);
-        document.removeEventListener("visibilitychange", handleVisibility);
-        clearInterval(heartbeatTimer);
-
-        root.innerHTML = "<h2>You must be signed in to join a room.</h2><p><a href='/join.html'>Back to safety</a></p>";
-        root.classList.remove("loading");
+        // Initial auth state may be null while anonymous sign-in completes.
+        // Avoid showing an error immediately to allow the sign-in to finish.
+        // If sign-in truly fails, the user can refresh to retry.
+        return;
     }
 });
 
@@ -209,7 +199,8 @@ async function startGame(players) {
  * Handles the "copy invite link" functionality.
  */
 copyInviteBtn.onclick = () => {
-    navigator.clipboard.writeText(window.location.href).then(() => {
+    const joinLink = `${location.origin}/join.html?room=${roomId}`;
+    navigator.clipboard.writeText(joinLink).then(() => {
         showToast('Invite link copied!', 'success');
     }).catch(err => {
         console.error('Could not copy text: ', err);


### PR DESCRIPTION
## Summary
- avoid showing an auth error while anonymous sign-in is still pending
- copy invite links to the join page instead of the lobby
- auto-join a room when visiting `join.html?room=...`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68612936f860832590dbaac436a305ed