### PR TITLE
Add subtle transitions to enhance UX

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -45,6 +45,13 @@ body {
   border-radius:var(--radius);
   box-shadow:var(--shadow);
   text-align:center;
+  opacity:0;                /* fade in once data loads */
+  transform:translateY(20px);
+  transition:opacity .4s ease, transform .4s ease;
+}
+#root.loaded{
+  opacity:1;
+  transform:translateY(0);
 }
 /* ─── 3. BOARD LAYOUT ─────────────────────────────────────────── */
 #board{
@@ -71,6 +78,7 @@ body {
   font-size:.9rem;
   background:#e0e0e0;      /* neutral until result known */
   color:#333;
+  transition:background-color .3s ease, transform .3s ease;
 }
 
 /* Colour swaps once a result is set */

--- a/public/join.html
+++ b/public/join.html
@@ -58,11 +58,12 @@
       border:1px solid #e0e0e0;
       border-radius:var(--radius);
       cursor:pointer;
-      transition: background .2s, border-color .2s;
+      transition: background .2s, border-color .2s, transform .2s;
     }
-    .room-card:hover{ 
-        background:#eef2ff; 
+    .room-card:hover{
+        background:#eef2ff;
         border-color: #c7d2fe;
+        transform:scale(1.02);
     }
     .room-name{ font-weight:600; }
     .room-meta{ font-size:.85rem; color:#555; }


### PR DESCRIPTION
## Summary
- add fade-in animation for main pages via `#root` styling
- smooth mission chip state changes
- subtle hover scaling on room list cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861299864f8832581bc57a1794fe2aa