### PR TITLE
Add theme-based missions with AI fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ Web game, based on The Resistance - social deduction
 The `functions` directory contains a scheduled Cloud Function that removes
 stale lobbies. It deletes any room that hasn't started and has seen no
 `lastActivity` updates for more than 15 minutes.
+
+## AI-generated mission themes
+
+Set an `OPENAI_API_KEY` environment variable for the Cloud Functions
+deployment to enable automatic mission generation based on a lobby theme.
+If the key is missing or the API call fails, placeholder missions are used
+so the game can still start.

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,6 +4,7 @@
   "engines": {"node": "16"},
   "dependencies": {
     "firebase-admin": "^11.10.1",
-    "firebase-functions": "^4.4.1"
+    "firebase-functions": "^4.4.1",
+    "node-fetch": "^2.6.11"
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -61,6 +61,11 @@ body {
   flex-wrap:wrap;      /* wraps on small screens */
 }
 
+#missionDesc{
+  font-style: italic;
+  margin-bottom: .5rem;
+}
+
 .mission-chip{
   width:40px;
   height:40px;

--- a/public/game.html
+++ b/public/game.html
@@ -40,6 +40,7 @@
         <!-- Mission / Leader header -->
         <h3>Mission <span id="missionNo">1</span></h3>
         <p>Leader: <strong id="leaderName"></strong></p>
+        <p id="missionDesc"></p>
 
         <!-- Mission history track -->
         <div id="mission-results"></div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -18,6 +18,7 @@ const contBtn           = $("#continue");
 const board             = $("#board");
 const missionNo         = $("#missionNo");
 const leaderNm          = $("#leaderName");
+const missionDesc       = $("#missionDesc");
 const leaderPan         = $("#leaderPanel");
 const neededSP          = $("#needed");
 const checkBoxC         = $("#playersChecklist");
@@ -250,6 +251,7 @@ function renderBoard() {
 
   missionNo.textContent = data.mission;
   leaderNm.textContent  = uidName(data.leaderUid);
+  missionDesc.textContent = (data.missions && data.missions[data.mission - 1]) || '';
 
   /* ------------ render mission history chips ------------- */
   renderMissionTrack();

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -41,6 +41,8 @@
       <ul id="player-list"></ul>
 
       <div class="actions">
+        <label for="themeInput">Theme:</label>
+        <input id="themeInput" type="text" placeholder="e.g. WW2" />
         <div id="start-game-container"></div>
         <button id="copy-invite-btn">Copy Invite Link</button>
       </div>

--- a/test/cleanupStaleRooms.test.js
+++ b/test/cleanupStaleRooms.test.js
@@ -42,6 +42,7 @@ test('cleanupStaleRooms deletes stale rooms', async () => {
   Module._load = (request, parent, isMain) => {
     if (request === 'firebase-admin') return adminMock;
     if (request === 'firebase-functions') return functionsMock;
+    if (request === 'node-fetch') return async () => {}; // unused in this test
     return originalLoad(request, parent, isMain);
   };
 

--- a/test/generateMissions.test.js
+++ b/test/generateMissions.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const Module = require('module');
+
+process.env.OPENAI_API_KEY = '';
+
+test('generateMissions falls back when API key missing', async () => {
+  let fetchCalled = false;
+  const fetchMock = async () => { fetchCalled = true; };
+
+  const adminMock = { initializeApp: () => {}, firestore: () => ({}) };
+  const functionsMock = {
+    region: () => ({
+      https: { onRequest: fn => fn },
+      pubsub: { schedule: () => ({ onRun: fn => fn }) }
+    })
+  };
+
+  const originalLoad = Module._load;
+  Module._load = (request, parent, isMain) => {
+    if (request === 'firebase-admin') return adminMock;
+    if (request === 'firebase-functions') return functionsMock;
+    if (request === 'node-fetch') return fetchMock;
+    return originalLoad(request, parent, isMain);
+  };
+
+  const fn = require('../functions/index.js').generateMissions;
+  Module._load = originalLoad;
+
+  const req = { body: { theme: 'Test' }, query: {} };
+  let statusCode;
+  let jsonData;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(data) { jsonData = data; }
+  };
+
+  await fn(req, res);
+
+  assert.strictEqual(statusCode, 200);
+  assert.deepStrictEqual(jsonData.missions, [
+    'Test mission 1',
+    'Test mission 2',
+    'Test mission 3',
+    'Test mission 4',
+    'Test mission 5'
+  ]);
+  assert.strictEqual(fetchCalled, false);
+});
+


### PR DESCRIPTION
## Summary
- allow lobby leader to enter an optional theme
- fetch AI-generated missions via new `generateMissions` cloud function
- store theme and missions when starting a game
- display mission descriptions during game play
- document OPENAI_API_KEY usage
- test mission generator fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68612a15a05c83259c447746935dd992