### PR TITLE
Add basic 3D mission board

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -67,6 +67,10 @@ body {
   justify-content:center;
   flex-wrap:wrap;      /* wraps on small screens */
 }
+#three-container {
+  width:100%;
+  height:300px;
+}
 
 #missionDesc{
   font-style: italic;

--- a/public/game.html
+++ b/public/game.html
@@ -13,6 +13,7 @@
   <script type="module" src="https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js"></script>
   <script type="module" src="https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js"></script>
 
+
   <!-- Your code -->
   <script type="module" src="/js/firebase-init.js"></script>
   <script type="module" src="/js/game.js"></script>
@@ -44,6 +45,7 @@
 
         <!-- Mission history track -->
         <div id="mission-results"></div>
+        <div id="three-container" style="width:100%;height:300px;"></div>
 
         <!-- STATUS / INFO line -->
         <p id="status"></p>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -3,6 +3,7 @@ import { db, auth } from "./firebase-init.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js";
 import { doc, onSnapshot, updateDoc, serverTimestamp, Timestamp } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js";
 import { missionTeamSize } from "./utils.mjs";
+import { init3DBoard, updateMission3D } from "./three-board.js";
 
 const roomId = new URLSearchParams(location.search).get("room");
 const roomRef = doc(db, "rooms", roomId);
@@ -10,6 +11,7 @@ const roomRef = doc(db, "rooms", roomId);
 /* ---------- cached state ---------- */
 let me, data;
 let heartbeatTimer = null;
+let threeInitialized = false;
 
 /* ---------- elements ---------- */
 const $ = (sel) => document.querySelector(sel);
@@ -29,6 +31,7 @@ const approveBt         = $("#approveBtn");
 const rejectBt          = $("#rejectBtn");
 const statusP           = $("#status");
 const missionResultsDiv = $("#mission-results"); // track container (row of chips)
+const threeContainer   = $("#three-container");
 
 // Mission panel elements
 const missionPan       = $("#missionPanel");
@@ -103,6 +106,10 @@ onSnapshot(roomRef, (snap) => {
 contBtn.onclick = () => {
   roleDiv.hidden = contBtn.hidden = true;
   board.hidden   = false;
+  if (!threeInitialized) {
+    init3DBoard(threeContainer);
+    threeInitialized = true;
+  }
   renderBoard();
 };
 
@@ -230,6 +237,7 @@ function renderMissionTrack() {
     }
 
     missionResultsDiv.appendChild(chip);
+    updateMission3D(i, result);
   }
 }
 

--- a/public/js/three-board.js
+++ b/public/js/three-board.js
@@ -1,0 +1,45 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+
+let scene, camera, renderer;
+const cubes = [];
+
+export function init3DBoard(container) {
+  const width = container.clientWidth || 300;
+  const height = container.clientHeight || 300;
+  scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(width, height);
+  container.appendChild(renderer.domElement);
+
+  camera.position.z = 5;
+
+  const geometry = new THREE.BoxGeometry(1, 1, 1);
+  for (let i = 0; i < 5; i++) {
+    const material = new THREE.MeshBasicMaterial({ color: 0x888888 });
+    const cube = new THREE.Mesh(geometry, material);
+    cube.position.x = (i - 2) * 1.5;
+    cubes.push(cube);
+    scene.add(cube);
+  }
+
+  animate();
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  cubes.forEach((cube) => {
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+  });
+  renderer.render(scene, camera);
+}
+
+export function updateMission3D(index, result) {
+  const cube = cubes[index - 1];
+  if (!cube) return;
+  let color = 0x888888;
+  if (result === 'success') color = 0x28a745;
+  else if (result === 'fail') color = 0xd32f2f;
+  cube.material.color.setHex(color);
+}


### PR DESCRIPTION
## Summary
- add a simple Three.js-based mission board renderer
- hook 3D board init into game flow
- update mission track to colour 3D cubes
- add container and style for the 3D canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ceb16b1f083258b577b8d32e9face